### PR TITLE
Resolve Error that prevent highlighting from working

### DIFF
--- a/sticky-chrome-extension/manifest.json
+++ b/sticky-chrome-extension/manifest.json
@@ -12,10 +12,7 @@
     {
       "run_at": "document_start",
       "js": [
-        "before.js",
-        "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
-        "medium-highlighter.js",
-        "content.js"
+        "before.js"
       ],
       "matches": [
         "https://*/*",
@@ -25,7 +22,12 @@
 
     {
       "run_at": "document_idle",
-      "js": [ "after.js" ],
+      "js": [ 
+        "after.js",
+        "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
+        "medium-highlighter.js",
+        "content.js" 
+      ],
       "matches": [
         "https://*/*",
         "http://*/*"


### PR DESCRIPTION
Cause of the error:
 in manifest.json file, There is a place to set when javascript files should be executed during webpage loading. Three files are associated with the highlighting feature
 "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
"medium-highlighter.js",
"content.js"

these files set to "run_at": "document_idle" attribute.